### PR TITLE
Create Channels Functionality

### DIFF
--- a/components/routes/incoming_webhooks.js
+++ b/components/routes/incoming_webhooks.js
@@ -1,4 +1,5 @@
 const debug = require('debug')('botkit:incoming_webhooks')
+const request = require('request')
 
 module.exports = function (webserver, controller) {
   debug('Configured /slack/receive url')
@@ -9,5 +10,54 @@ module.exports = function (webserver, controller) {
 
     // Now, pass the webhook into be processed
     controller.handleWebhookPayload(req, res)
+  })
+
+  webserver.post('/new-cohort', function (req, res) {
+    const cohort = req.body.text.split(' ')[0]
+    const immersive = req.body.text.split(' ')[1]
+    const responseUrl = req.body.response_url
+
+    const channelTypes = [
+      'forum',
+      'planning',
+      'code',
+      'etc',
+      'links',
+      'projects',
+      'outcomes'
+    ]
+
+    res.status(201).json({
+      response_type: 'ephemeral',
+      text: `Working on that...`
+    })
+    let token
+
+    controller.store.getTeam(req.body.team_id)
+      .then(team => {
+        token = team.oauth_token
+        const channelsToCreate = channelTypes.map(type => {
+          return controller.createChannel(`${immersive}-bos-${cohort}-${type}`, token)
+        })
+        return Promise.all(channelsToCreate)
+      })
+      .then(res => {
+        const invitees = res.map(r => {
+          return controller.channelJoin(r.group.id, req.body.user_id, token)
+        })
+        return Promise.all(invitees)
+      })
+      .then(res => {
+        request({
+          method: 'POST',
+          uri: responseUrl,
+          body: {
+            response_type: 'in_channel',
+            text: 'Done!'
+          },
+          json: true
+        })
+      })
+      .catch(console.error)
   })
 }

--- a/skills/channels.js
+++ b/skills/channels.js
@@ -1,0 +1,13 @@
+const { WebClient } = require('@slack/web-api')
+
+module.exports = controller => {
+  controller.channelJoin = function (channel, user, token) {
+    const web = new WebClient(token)
+    return web.groups.invite({ channel, user })
+  }
+
+  controller.createChannel = function (channelName, token) {
+    const web = new WebClient(token)
+    return web.groups.create({ name: channelName })
+  }
+}

--- a/skills/hears.js
+++ b/skills/hears.js
@@ -176,4 +176,15 @@ module.exports = function (controller) {
       })
       .catch(controller.logger.error)
   })
+
+  controller.hears('^create (.*)', 'direct_message', function (bot, message) {
+    // create a channel
+    controller.store.getTeam(message.team)
+      .then(team => {
+        const web = new WebClient(team.oauth_token)
+        return web.groups.create({ name: message.match[0].split(' ')[1] })
+      })
+      .then(controller.logger.info)
+      .catch(console.log)
+  })
 }


### PR DESCRIPTION
- Hears "create channel-name" handler will create a channel called
"channel-name"
- `skills/channels.js` has functions to call api `groups.create` and `groups.invite`
for new cohort launch channel creation.
- Add route for slash command that goes to `/new-cohort`. Command takes
in a cohort and immersive type - `'/new-cohort 04 sei'` will create all
relevant channels (like `'sei-bos-04-planning'`) based on the cohort and
immersive type, as well as invite the person running the slash command
to each new channel.